### PR TITLE
Change Riemann event service name

### DIFF
--- a/riemann-mysql.c
+++ b/riemann-mysql.c
@@ -225,7 +225,7 @@ mysql_gather(struct mysql_handler *hdl)
     ev = riemann_event_create(RIEMANN_EVENT_FIELD_HOST,
                               hostname,
                               RIEMANN_EVENT_FIELD_SERVICE,
-                              "mysql",
+                              "mysql/replication",
                               RIEMANN_EVENT_FIELD_TIME,
                               (int64_t)time(NULL),
                               RIEMANN_EVENT_FIELD_STATE,


### PR DESCRIPTION
This change renames the Riemann event service field to
"mysql/replication" in order to be a little more explanatory than just
"mysql".

At some point in the future this information could be user-supplied via configuration.